### PR TITLE
Updated MarkSafe to version 1.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ Flask==0.12.2
 idna==2.5
 itsdangerous==0.24
 Jinja2==2.9.6
-MarkupSafe==1.0
+MarkupSafe==1.1.0
 requests==2.18.3
 urllib3==1.22
 Werkzeug==0.12.2


### PR DESCRIPTION
Couldn't run pip install with version 1.0