### PR TITLE
fix: bump MarkupSafe to 2.0.0 in order to fix setuptools incompatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ Flask==0.12.2
 idna==2.5
 itsdangerous==0.24
 Jinja2==2.9.6
-MarkupSafe==1.0
+MarkupSafe==2.0.0
 requests==2.18.3
 urllib3==1.22
 Werkzeug==0.12.2


### PR DESCRIPTION
Bump MarkupSafe version in order to overcome setuptools incompatibility